### PR TITLE
Add optional traslational offset to frame related methods 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(INCLUDE_DIRS yarpWholeBodyInterface)
 
 set(${VARS_PREFIX}_MAJOR_VERSION 0)
 set(${VARS_PREFIX}_MINOR_VERSION 2)
-set(${VARS_PREFIX}_PATCH_VERSION 3)
+set(${VARS_PREFIX}_PATCH_VERSION 4)
 set(${VARS_PREFIX}_VERSION ${${VARS_PREFIX}_MAJOR_VERSION}.${${VARS_PREFIX}_MINOR_VERSION}.${${VARS_PREFIX}_PATCH_VERSION})
 
 find_package(YCM REQUIRED)
@@ -25,8 +25,8 @@ option(YARPWHOLEBODYINTERFACE_ENABLE_TESTS "Enable unit testing" FALSE)
 
 
 find_package(YARP 2.3.63.7 REQUIRED)
-find_package(iDynTree 0.3.6 REQUIRED)
-find_package(wholeBodyInterface 0.2.3 REQUIRED)
+find_package(iDynTree 0.3.11 REQUIRED)
+find_package(wholeBodyInterface 0.2.4 REQUIRED)
 
 SET(folder_source src/yarpWbiUtil.cpp
                   src/yarpWholeBodyInterface.cpp

--- a/include/yarpWholeBodyInterface/yarpWholeBodyInterface.h
+++ b/include/yarpWholeBodyInterface/yarpWholeBodyInterface.h
@@ -138,10 +138,10 @@ namespace yarpWbi
         virtual const wbi::IDList& getJointList();
         virtual const wbi::IDList& getFrameList();
         virtual bool getJointLimits(double *qMin, double *qMax, int joint=-1);
-        virtual bool computeH(double *q, const wbi::Frame &xB, int linkId, wbi::Frame &H);
+        virtual bool computeH(double *q, const wbi::Frame &xB, int linkId, wbi::Frame &H, double *pos);
         virtual bool computeJacobian(double *q, const wbi::Frame &xB, int linkId, double *J, double *pos=0);
         virtual bool computeDJdq(double *q, const wbi::Frame &xB, double *dq, double *dxB, int linkId, double *dJdq, double *pos=0);
-        virtual bool forwardKinematics(double *q, const wbi::Frame &xB, int linkId, double *x);
+        virtual bool forwardKinematics(double *q, const wbi::Frame &xB, int linkId, double *x, double *pos);
         virtual bool inverseDynamics(double *q, const wbi::Frame &xB, double *dq, double *dxB, double *ddq, double *ddxB, double *g, double *tau);
         virtual bool computeMassMatrix(double *q, const wbi::Frame &xB, double *M);
         virtual bool computeGeneralizedBiasForces(double *q, const wbi::Frame &xB, double *dq, double *dxB, double *g, double *h);

--- a/src/yarpWholeBodyInterface.cpp
+++ b/src/yarpWholeBodyInterface.cpp
@@ -290,9 +290,9 @@ bool yarpWholeBodyInterface::getJointLimits(double* qMin, double* qMax,
     return modelInt->getJointLimits(qMin, qMax, joint);
 }
 bool yarpWholeBodyInterface::computeH(double* q, const wbi::Frame& xB,
-    int linkId, wbi::Frame& H)
+    int linkId, wbi::Frame& H, double *pos)
 {
-    return modelInt->computeH(q, xB, linkId, H);
+    return modelInt->computeH(q, xB, linkId, H, pos);
 }
 bool yarpWholeBodyInterface::computeJacobian(double* q, const wbi::Frame& xB,
     int linkId, double* J,
@@ -307,9 +307,9 @@ bool yarpWholeBodyInterface::computeDJdq(double* q, const wbi::Frame& xB,
     return modelInt->computeDJdq(q, xB, dq, dxB, linkId, dJdq, pos);
 }
 bool yarpWholeBodyInterface::forwardKinematics(double* q, const wbi::Frame& xB,
-    int linkId, double* x)
+    int linkId, double* x, double *pos)
 {
-    return modelInt->forwardKinematics(q, xB, linkId, x);
+    return modelInt->forwardKinematics(q, xB, linkId, x, pos);
 }
 bool yarpWholeBodyInterface::inverseDynamics(double* q, const wbi::Frame& xB,
     double* dq, double* dxB,

--- a/src/yarpWholeBodyModel.cpp
+++ b/src/yarpWholeBodyModel.cpp
@@ -503,8 +503,6 @@ bool yarpWholeBodyModel::computeJacobian(double *q, const Frame &xBase, int link
 {
     if( (linkId < 0 || linkId >= p_model->getNrOfLinks()) && linkId != COM_LINK_ID ) return false;
 
-    if( pos != 0 ) return false; //not implemented yet
-
     bool ret_val;
 
     int dof_jacobian = dof+6;
@@ -557,7 +555,6 @@ bool yarpWholeBodyModel::computeJacobian(double *q, const Frame &xBase, int link
 bool yarpWholeBodyModel::computeDJdq(double *q, const Frame &xBase, double *dq, double *dxB, int linkID, double *dJdq, double *pos)
 {
     if ((linkID < 0 || linkID >= p_model->getNrOfLinks()) && linkID != COM_LINK_ID) return false;
-    if (pos != 0) return false; //not implemented yet
 
     //joints
     convertQ(q, all_q);

--- a/tests/yarpWholeBodyRootWorldTest/main.cpp
+++ b/tests/yarpWholeBodyRootWorldTest/main.cpp
@@ -193,7 +193,6 @@ int main(int argc, char * argv[])
       printf("Qd:  %s\n", (yarpWbi::Rad2Deg*qd).toString(1).c_str());
       icub->setControlParam(CTRL_PARAM_REF_VEL, refSpeed.data());
       icub->setControlReference(qd.data());
-      int j = 0;
       Eigen::Matrix<double,6,Dynamic,RowMajor> jacob;
       jacob.resize(6,dof+6); //13 because in this test we only have right and left arm plus torso
 


### PR DESCRIPTION
Depends on https://github.com/robotology/wholebodyinterface/pull/14 .

@jeljaik could you try it from this branch ? Otherwise I can simply merge, in theory it does not affect the default behavior.

Fake PR testing the whole codyco-superbuild : https://github.com/robotology/codyco-superbuild/issues/111 . 