### PR TITLE
fixed a bug in yarpWholeBodyModelV2

### DIFF
--- a/include/yarpWholeBodyInterface/yarpWholeBodyModelV2.h
+++ b/include/yarpWholeBodyInterface/yarpWholeBodyModelV2.h
@@ -71,7 +71,6 @@ namespace yarpWbi
         wbi::IDList jointIdList;
         wbi::IDList frameIdList;
         bool initDone;
-        int dof;
         yarp::os::Property wbi_yarp_properties;
 
         // iDynTree class actually used for all computations

--- a/src/yarpWholeBodyModelV2.cpp
+++ b/src/yarpWholeBodyModelV2.cpp
@@ -61,7 +61,6 @@ using namespace iCub::skinDynLib;
 yarpWholeBodyModelV2::yarpWholeBodyModelV2(const char* _name,
                                        const yarp::os::Property & _wbi_yarp_conf)
         : initDone(false),
-          dof(0),
           wbi_yarp_properties(_wbi_yarp_conf),
           getLimitsFromControlBoard(false)
 {
@@ -243,6 +242,7 @@ bool yarpWholeBodyModelV2::getYarpWbiProperties(yarp::os::Property & yarp_wbi_pr
 
 int yarpWholeBodyModelV2::getDoFs()
 {
+    int dof = jointIdList.size();
     return dof;
 }
 


### PR DESCRIPTION
The variable `dof` was initialized to zero and not modified anymore in the code. This caused a bug in [mex-wholebodymodel](https://github.com/robotology/mex-wholebodymodel), where the controller was trying to read that variable in order to retrieve the number of dofs in the model (see issue https://github.com/robotology/mex-wholebodymodel/issues/76).