### PR TITLE
fixed an error with colors in bigman urdf

### DIFF
--- a/app/robots/bigman/bigman_torqueBalancing.urdf
+++ b/app/robots/bigman/bigman_torqueBalancing.urdf
@@ -136,6 +136,9 @@
   <material name="blue">
     <color rgba="0.0 0.2 0.3 1"/>
   </material>
+  <material name="black">
+    <color rgba="0.0 0.0 0.0 1"/>
+  </material>
   <!-- ************ BIGMAN BASE ************** -->
   <!-- 
   ROS urdf definition of the BIGMAN humanoid robot by Istituto Italiano di Tecnologia

--- a/app/robots/bigman_only_legs/bigman_torqueBalancing_only_legs.urdf
+++ b/app/robots/bigman_only_legs/bigman_torqueBalancing_only_legs.urdf
@@ -136,6 +136,9 @@
   <material name="blue">
     <color rgba="0.0 0.2 0.3 1"/>
   </material>
+  <material name="black">
+    <color rgba="0.0 0.0 0.0 1"/>
+  </material>
   <!-- ************ BIGMAN BASE ************** -->
   <!-- 
   ROS urdf definition of the BIGMAN humanoid robot by Istituto Italiano di Tecnologia


### PR DESCRIPTION
There was a missing color definition (black) at the beginning of the urdf code. This caused an error when the model was loaded using iDyntree. Now the error is fixed with this commit