### PR TITLE
added joint list for matlab controllers

### DIFF
--- a/app/robots/bigman_only_legs/yarpWholeBodyInterface.ini
+++ b/app/robots/bigman_only_legs/yarpWholeBodyInterface.ini
@@ -36,6 +36,7 @@ ROBOT_RIGHT_LEG_JOINTS                        = (RHipSag,RHipLat,RHipYaw,RKneeSa
 
 # List of robot models
 ROBOT_TORQUE_CONTROL_JOINTS                   = (ROBOT_LEFT_LEG_JOINTS, ROBOT_RIGHT_LEG_JOINTS)
+ROBOT_MEX_WBI_TOOLBOX                         = (ROBOT_LEFT_LEG_JOINTS, ROBOT_RIGHT_LEG_JOINTS)
 
 # List of imus of the robot
 ROBOT_MAIN_IMUS                               = (imu_link)


### PR DESCRIPTION
The joint list for mex-wholebodymodel was missing in `bigman_only_legs` configuration. I added it so I can use this robot with matlab controllers