### PR TITLE
Fix compatibility with YARP 2.3.69.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ option(YARPWBI_USES_KDL "Compile the parts of yarp-wholebodyinterface that depen
 option(YARPWBI_ENABLE_TESTS "Enable unit testing" FALSE)
 
 find_package(YARP 2.3.63.7 REQUIRED)
+if (${YARP_VERSION} VERSION_LESS 2.3.69.8)
+    add_definitions(-DYARPWBI_YARP_HAS_LEGACY_IOPENLOOP)
+endif ()
 
 if(YARPWBI_USES_KDL)
     find_package(iDynTree 0.3.14 REQUIRED)

--- a/include/yarpWholeBodyInterface/yarpWholeBodyActuators.h
+++ b/include/yarpWholeBodyInterface/yarpWholeBodyActuators.h
@@ -141,7 +141,9 @@ namespace yarpWbi
         std::vector<yarp::dev::IControlMode2*>        icmd;
         std::vector<yarp::dev::IInteractionMode*>     iinteraction;
         std::vector<yarp::dev::IVelocityControl2*>    ivel;
-        std::vector<yarp::dev::IOpenLoopControl*>     iopl;
+        // Temporary defined open loop as void to be compatible with both YARP master and devel
+        // see https://github.com/robotology/yarp-wholebodyinterface/issues/72
+        std::vector<void*>     iopl;
         std::vector<yarp::dev::PolyDriver*>           dd;
 
         /**

--- a/include/yarpWholeBodyInterface/yarpWholeBodySensors.h
+++ b/include/yarpWholeBodyInterface/yarpWholeBodySensors.h
@@ -135,7 +135,9 @@ namespace yarpWbi
 
         // yarp interfaces (the "key" of these vector is wbi numeric controlboard id
         std::vector<yarp::dev::IEncodersTimed*>       ienc;   // interface to read encoders
-        std::vector<yarp::dev::IOpenLoopControl*>     iopl;   // interface to read motor PWM
+        // Temporary defined open loop as void to be compatible with both YARP master and devel
+        // see https://github.com/robotology/yarp-wholebodyinterface/issues/72
+        std::vector<void*>     iopl;   // interface to read motor PWM
         std::vector<yarp::dev::PolyDriver*>           dd; //device drivers
         std::vector<yarp::dev::ITorqueControl*>       itrq;  // interface to read joint torques
 

--- a/src/yarpWholeBodyActuators.cpp
+++ b/src/yarpWholeBodyActuators.cpp
@@ -39,6 +39,10 @@ const std::string yarpWbi::YarpWholeBodyActuatorsPropertyInteractionModeComplian
 const std::string yarpWbi::YarpWholeBodyActuatorsPropertyImpedanceStiffnessKey = "yarp.dev.impedance.stiffness";
 const std::string yarpWbi::YarpWholeBodyActuatorsPropertyImpedanceDampingKey = "yarp.dev.impedance.damping";
 
+#ifdef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
+#define VOCAB_CM_PWM VOCAB_CM_OPENLOOP
+#endif
+
 
 // *********************************************************************************************************************
 // *********************************************************************************************************************
@@ -401,7 +405,7 @@ bool yarpWholeBodyActuators::setControlModeSingleJoint(ControlMode controlMode, 
                 }
                 break;
             case CTRL_MODE_MOTOR_PWM:
-                ok = icmd[bodyPart]->setControlMode(controlBoardJointAxis,VOCAB_CM_OPENLOOP);
+                ok = icmd[bodyPart]->setControlMode(controlBoardJointAxis,VOCAB_CM_PWM);
                 break;
             default:
                 break;
@@ -490,7 +494,11 @@ bool yarpWholeBodyActuators::setControlReference(double *ref, int joint)
             }
                 break;
             case CTRL_MODE_MOTOR_PWM:
-                ret_value = iopl[bodyPart]->setRefOutput(controlBoardAxis, *ref);
+#ifndef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
+                ret_value = ((IPWMControl*)iopl[bodyPart])->setRefDutyCycle(controlBoardAxis, *ref);
+#else
+                ret_value = ((IOpenLoopControl*)iopl[bodyPart])->setRefOutput(controlBoardAxis, *ref);
+#endif
                 break;
             default:
                 ret_value = false;
@@ -669,10 +677,14 @@ bool yarpWholeBodyActuators::setControlReference(double *ref, int joint)
                 for( int controlBoard_jnt = 0; controlBoard_jnt < nrOfPWMControlledJointsInControlBoard; controlBoard_jnt++ )
                 {
                     int wbi_id = controlledJointsForControlBoard.pwmControlledJoints[wbi_controlboard_id][controlBoard_jnt].wbi_id;
-                    int yarp_controlboard_axis =  controlledJointsForControlBoard.pwmControlledJoints[wbi_controlboard_id][controlBoard_jnt].yarp_controlboard_axis;
+                    int yarp_controlboard_axis = controlledJointsForControlBoard.pwmControlledJoints[wbi_controlboard_id][controlBoard_jnt].yarp_controlboard_axis;
                     buf_references[yarp_controlboard_axis] = ref[wbi_id];
                 }
-                ok = iopl[wbi_controlboard_id]->setRefOutputs(buf_references);
+#ifndef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
+                ok = ((IPWMControl*)iopl[wbi_controlboard_id])->setRefDutyCycles(buf_references);
+#else
+                ok = ((IOpenLoopControl*)iopl[wbi_controlboard_id])->setRefOutputs(buf_references);
+#endif
                 if(!ok)
                 {
                     std::cerr << "yarpWholeBodyActuators::setControlReference error:"
@@ -687,7 +699,11 @@ bool yarpWholeBodyActuators::setControlReference(double *ref, int joint)
                 {
                     int wbi_id = controlledJointsForControlBoard.pwmControlledJoints[wbi_controlboard_id][controlBoard_jnt].wbi_id;
                     int yarp_controlboard_axis =  controlledJointsForControlBoard.pwmControlledJoints[wbi_controlboard_id][controlBoard_jnt].yarp_controlboard_axis;
-                    ok = iopl[wbi_controlboard_id]->setRefOutput(yarp_controlboard_axis,ref[wbi_id]);
+#ifndef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
+                    ok = ((IPWMControl*)iopl[wbi_controlboard_id])->setRefDutyCycle(yarp_controlboard_axis,ref[wbi_id]);
+#else
+                    ok = ((IOpenLoopControl*)iopl[wbi_controlboard_id])->setRefOutput(yarp_controlboard_axis,ref[wbi_id]);
+#endif
                 }
             }
         }
@@ -746,7 +762,7 @@ ControlMode yarpWholeBodyActuators::yarpToWbiCtrlMode(int yarpCtrlMode)
     case VOCAB_CM_TORQUE:   return CTRL_MODE_TORQUE;
     case VOCAB_CM_POSITION: return CTRL_MODE_POS;
     case VOCAB_CM_VELOCITY: return CTRL_MODE_VEL;
-    case VOCAB_CM_OPENLOOP: return CTRL_MODE_MOTOR_PWM;
+    case VOCAB_CM_PWM: return CTRL_MODE_MOTOR_PWM;
     }
     return CTRL_MODE_UNKNOWN;
 }

--- a/src/yarpWholeBodySensors.cpp
+++ b/src/yarpWholeBodySensors.cpp
@@ -709,7 +709,12 @@ bool yarpWholeBodySensors::readPwms(double *pwm, double *stamps, bool wait)
     {
         // read data
         double waiting_time = 0;
-        while( !(update=iopl[*ctrlBoard]->getOutputs(pwmTemp)) && wait)
+
+#ifndef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
+        while( !(update=((IPWMControl*)iopl[*ctrlBoard])->getDutyCycles(pwmTemp)) && wait)
+#else
+        while( !(update=((IOpenLoopControl*)iopl[*ctrlBoard])->getOutputs(pwmTemp)) && wait)
+#endif
         {
             Time::delay(WAIT_TIME);
 
@@ -901,7 +906,11 @@ bool yarpWholeBodySensors::readPwm(const int pwm_numeric_id, double *pwm, double
 
     // read pwm sensors
     double waiting_time = 0.0;
-    while( !(update=iopl[pwmCtrlBoard]->getOutputs(pwmLastRead[pwmCtrlBoard].data())) && wait)
+#ifndef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
+    while( !(update=((IPWMControl*)iopl[pwmCtrlBoard])->getDutyCycles(pwmLastRead[pwmCtrlBoard].data())) && wait)
+#else
+    while( !(update=((IOpenLoopControl*)iopl[pwmCtrlBoard])->getOutputs(pwmLastRead[pwmCtrlBoard].data())) && wait)
+#endif
     {
         Time::delay(WAIT_TIME);
 


### PR DESCRIPTION
In particular, remain compatible with both IOpenLoop (removed) and with the new IPWMControl.

Fix https://github.com/robotology/yarp-wholebodyinterface/issues/72 .