### PR TITLE
Revert "Fix compatibility with YARP 2.3.69.8"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,6 @@ option(YARPWBI_USES_KDL "Compile the parts of yarp-wholebodyinterface that depen
 option(YARPWBI_ENABLE_TESTS "Enable unit testing" FALSE)
 
 find_package(YARP 2.3.63.7 REQUIRED)
-if (${YARP_VERSION} VERSION_LESS 2.3.69.8)
-    add_definitions(-DYARPWBI_YARP_HAS_LEGACY_IOPENLOOP)
-endif ()
 
 if(YARPWBI_USES_KDL)
     find_package(iDynTree 0.3.14 REQUIRED)

--- a/include/yarpWholeBodyInterface/yarpWholeBodyActuators.h
+++ b/include/yarpWholeBodyInterface/yarpWholeBodyActuators.h
@@ -141,9 +141,7 @@ namespace yarpWbi
         std::vector<yarp::dev::IControlMode2*>        icmd;
         std::vector<yarp::dev::IInteractionMode*>     iinteraction;
         std::vector<yarp::dev::IVelocityControl2*>    ivel;
-        // Temporary defined open loop as void to be compatible with both YARP master and devel
-        // see https://github.com/robotology/yarp-wholebodyinterface/issues/72
-        std::vector<void*>     iopl;
+        std::vector<yarp::dev::IOpenLoopControl*>     iopl;
         std::vector<yarp::dev::PolyDriver*>           dd;
 
         /**

--- a/include/yarpWholeBodyInterface/yarpWholeBodySensors.h
+++ b/include/yarpWholeBodyInterface/yarpWholeBodySensors.h
@@ -135,9 +135,7 @@ namespace yarpWbi
 
         // yarp interfaces (the "key" of these vector is wbi numeric controlboard id
         std::vector<yarp::dev::IEncodersTimed*>       ienc;   // interface to read encoders
-        // Temporary defined open loop as void to be compatible with both YARP master and devel
-        // see https://github.com/robotology/yarp-wholebodyinterface/issues/72
-        std::vector<void*>     iopl;   // interface to read motor PWM
+        std::vector<yarp::dev::IOpenLoopControl*>     iopl;   // interface to read motor PWM
         std::vector<yarp::dev::PolyDriver*>           dd; //device drivers
         std::vector<yarp::dev::ITorqueControl*>       itrq;  // interface to read joint torques
 

--- a/src/yarpWholeBodySensors.cpp
+++ b/src/yarpWholeBodySensors.cpp
@@ -709,12 +709,7 @@ bool yarpWholeBodySensors::readPwms(double *pwm, double *stamps, bool wait)
     {
         // read data
         double waiting_time = 0;
-
-#ifndef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
-        while( !(update=((IPWMControl*)iopl[*ctrlBoard])->getDutyCycles(pwmTemp)) && wait)
-#else
-        while( !(update=((IOpenLoopControl*)iopl[*ctrlBoard])->getOutputs(pwmTemp)) && wait)
-#endif
+        while( !(update=iopl[*ctrlBoard]->getOutputs(pwmTemp)) && wait)
         {
             Time::delay(WAIT_TIME);
 
@@ -906,11 +901,7 @@ bool yarpWholeBodySensors::readPwm(const int pwm_numeric_id, double *pwm, double
 
     // read pwm sensors
     double waiting_time = 0.0;
-#ifndef YARPWBI_YARP_HAS_LEGACY_IOPENLOOP
-    while( !(update=((IPWMControl*)iopl[pwmCtrlBoard])->getDutyCycles(pwmLastRead[pwmCtrlBoard].data())) && wait)
-#else
-    while( !(update=((IOpenLoopControl*)iopl[pwmCtrlBoard])->getOutputs(pwmLastRead[pwmCtrlBoard].data())) && wait)
-#endif
+    while( !(update=iopl[pwmCtrlBoard]->getOutputs(pwmLastRead[pwmCtrlBoard].data())) && wait)
     {
         Time::delay(WAIT_TIME);
 


### PR DESCRIPTION
Reverts robotology/yarp-wholebodyinterface#74 , due to https://github.com/robotology-playground/WBI-Toolbox-controllers/issues/52 .