### PR TITLE
Disable /Wall compiler option on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,9 @@ endif ()
 source_group("Source Files" FILES ${folder_source})
 source_group("Header Files" FILES ${folder_header})
 
-add_definitions(-Wall)
+if (NOT ${MSVC})
+    add_definitions(-Wall)
+endif ()
 
 # import math symbols from standard cmath
 add_definitions(-D_USE_MATH_DEFINES)


### PR DESCRIPTION
On Visual Studio, `/Wall` is a level of warning that report warning that are not actually warnings 
(see https://msdn.microsoft.com/en-us/library/thxezb7y.aspx). 
To reduce the log in AppVeyor build of the codyco-superbuild , I think we can disable this warnings (even considering that this library should be deprecated sooner or later).