### PR TITLE
Using iPidInterface to get references.

### DIFF
--- a/include/yarpWholeBodyInterface/yarpWholeBodyActuators.h
+++ b/include/yarpWholeBodyInterface/yarpWholeBodyActuators.h
@@ -141,6 +141,7 @@ namespace yarpWbi
         std::vector<yarp::dev::IControlMode2*>        icmd;
         std::vector<yarp::dev::IInteractionMode*>     iinteraction;
         std::vector<yarp::dev::IVelocityControl2*>    ivel;
+        std::vector<yarp::dev::IPidControl*>          ipid;
         // Temporary defined open loop as void to be compatible with both YARP master and devel
         // see https://github.com/robotology/yarp-wholebodyinterface/issues/72
         std::vector<void*>     iopl;


### PR DESCRIPTION
This interface is faster on the robot. See https://github.com/robotology/icub-main/issues/475

The references from the openLoopControl mode are still slow to be obtained.

@francesco-romano 